### PR TITLE
Plot live updates over time

### DIFF
--- a/plot_mem_usage_live.py
+++ b/plot_mem_usage_live.py
@@ -1,0 +1,5 @@
+from src.dockerstats import *
+
+ds = DockerStats("data.csv")
+
+ds.plot_category_live('MEM Usage')

--- a/scripts/generate_data.sh
+++ b/scripts/generate_data.sh
@@ -2,15 +2,16 @@
 
 # Using linux date
 # For mac - brew install coreutils ; echo "alias date=gdate" >> ~/.bash_profile
-runtime="30 minutes"
+runtime="24 hours"
 endtime=$(date -ud "$runtime" +%s)
+echo "Collecting docker stats for ${runtime} or until cancelled..."
 
 # while true
 while [[ $(date -u +%s) -le ${endtime} ]]
 do docker stats --no-stream --format "table {{.Name}};{{.CPUPerc}};{{.MemPerc}};{{.MemUsage}};{{.NetIO}};{{.BlockIO}};{{.PIDs}}" > dockerstats
-tail -n +2 dockerstats | awk -v date=";$(date +%T)" '{print $0, date}' >> data.csv
-sleep 5
+tail -n +2 dockerstats | awk -v date=";$(date -u +'%Y-%m-%dT%H:%M:%SZ')" '{print $0, date}' >> data.csv
+sleep 1
 done
 
-cat data.csv
+echo "Finished after ${runtime} see data.csv"
 rm -rf dockerstats


### PR DESCRIPTION
Disclaimer: I'm not necessarily suggesting that this be merged as-is, but I didn't want my changes to be wasted if they might be useful to others.
So this is something I got working for my use case which is analysing long-term memory usage (e.g. over several hours) of a set of containers.

If there are parts of this which you think are useful then I'm happy to split them out / clean them up, or for you to pick and choose.

For comparison, there is some memory graphing in the Docker Desktop UI now, but it is only either per-container, or a total for all containers (rather than all containers on 1 graph) and also in my experience it is not always persistent or reliable (has gaps).

So anyway - if this just sits open as something potentially useful that's fine, or if you're interested in merging some/all then that's great too!